### PR TITLE
Do not strip by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,6 @@ endif
 
 ifdef debug
 	CFLAGS += -g
-else
-	CFLAGS += -s
 endif
 
 LDFLAGS ?= -Wl,-O1


### PR DESCRIPTION
make install != make install-strip

https://www.gnu.org/software/automake/manual/automake.html#Standard-Targets

Required for Gentoo packaging.
