### PR TITLE
Support RADEON_INFO_READ_REG queries

### DIFF
--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -44,12 +44,17 @@ enum {
 #ifndef RADEON_INFO_VRAM_USAGE
 #define RADEON_INFO_VRAM_USAGE 0x1e
 #endif
+#ifndef RADEON_INFO_READ_REG
+#define RADEON_INFO_READ_REG 0x24
+#endif
 
 // radeontop.c
 void die(const char *why);
+int get_drm_value(int fd, unsigned request, uint32_t *out);
 unsigned int readgrbm();
 
 extern const void *area;
+extern int use_ioctl;
 
 // detect.c
 unsigned int init_pci(unsigned char bus);


### PR DESCRIPTION
These queries are new in Linux 4.1 and make radeontop work even if
CONFIG_DEVMEM is disabled. Ubuntu recently disabled this feature in
the default distribution kernels.

Queries are always preferred to /dev/mem.