### PR TITLE
Bobs fixes

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -152,7 +152,7 @@ unsigned int init_pci(unsigned char bus) {
 		printf(_("Failed to open DRM node, no VRAM support.\n"));
 	} else {
 		drmDropMaster(drm_fd);
-		const drmVersion * const ver = drmGetVersion(drm_fd);
+		drmVersion * const ver = drmGetVersion(drm_fd);
 
 /*		printf("Version %u.%u.%u, name %s\n",
 			ver->version_major,
@@ -160,8 +160,12 @@ unsigned int init_pci(unsigned char bus) {
 			ver->version_patchlevel,
 			ver->name);*/
 
-		if (ver->version_major < 2 ||
-			ver->version_minor < 36) {
+		const int outdatedKernel = ver->version_major <= 2 && ver->version_minor <= 36;
+
+		// Free the allocated storage
+		drmFreeVersion(ver);
+
+		if (outdatedKernel) {
 			printf(_("Kernel too old for VRAM reporting.\n"));
 			goto out;
 		}
@@ -246,4 +250,10 @@ void initbits(int fam) {
 		bits.cr = 0;
 		bits.smx = 0;
 	}
+}
+
+void shutdown_pci(void) {
+
+	// Not much to do here
+	pci_system_cleanup();
 }

--- a/detect.c
+++ b/detect.c
@@ -171,7 +171,7 @@ unsigned int init_pci(unsigned char bus) {
 		}
 
 		// No version indicator, so we need to test once
-		int ret;
+
 		struct drm_radeon_gem_info gem;
 
 		ret = drmCommandWriteRead(drm_fd, DRM_RADEON_GEM_INFO,
@@ -227,24 +227,24 @@ void initbits(int fam) {
 
 	// The majority of these is the same from R600 to Southern Islands.
 
-	bits.ee = (1 << 10);
-	bits.vgt = (1 << 16) | (1 << 17);
-	bits.ta = (1 << 14);
-	bits.tc = (1 << 19);
-	bits.sx = (1 << 20);
-	bits.sh = (1 << 21);
-	bits.spi = (1 << 22);
-	bits.smx = (1 << 23);
-	bits.sc = (1 << 24);
-	bits.pa = (1 << 25);
-	bits.db = (1 << 26);
-	bits.cr = (1 << 27);
-	bits.cb = (1 << 30);
-	bits.gui = (1 << 31);
+	bits.ee = (1U << 10);
+	bits.vgt = (1U << 16) | (1U << 17);
+	bits.ta = (1U << 14);
+	bits.tc = (1U << 19);
+	bits.sx = (1U << 20);
+	bits.sh = (1U << 21);
+	bits.spi = (1U << 22);
+	bits.smx = (1U << 23);
+	bits.sc = (1U << 24);
+	bits.pa = (1U << 25);
+	bits.db = (1U << 26);
+	bits.cr = (1U << 27);
+	bits.cb = (1U << 30);
+	bits.gui = (1U << 31);
 
 	// R600 has a different texture bit, and only R600 has the TC, CR, SMX bits
 	if (fam < RV770) {
-		bits.ta = (1 << 18);
+		bits.ta = (1U << 18);
 	} else {
 		bits.tc = 0;
 		bits.cr = 0;

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -61,6 +61,7 @@ unsigned int init_pci(unsigned char bus);
 int getfamily(unsigned int id);
 void initbits(int fam);
 unsigned long long getvram();
+void shutdown_pci(void);
 
 // ticks.c
 void collect(unsigned int *ticks);

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -69,7 +69,7 @@ void collect(unsigned int *ticks);
 extern struct bits_t *results;
 
 // ui.c
-void present(const unsigned int ticks, const char card[], const unsigned int color);
+void present(const unsigned int ticks, const char card[], unsigned int color);
 
 // dump.c
 void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit);

--- a/radeontop.c
+++ b/radeontop.c
@@ -65,7 +65,7 @@ unsigned int readgrbm() {
 		get_drm_value(drm_fd, RADEON_INFO_READ_REG, &reg);
 		return reg;
 	} else {
-		const void *ptr = area + 0x10;
+		const void *ptr = (const char*)area + 0x10;
 		const unsigned int *inta = ptr;
 		return *inta;
 	}

--- a/radeontop.c
+++ b/radeontop.c
@@ -147,6 +147,10 @@ int main(int argc, char **argv) {
 	else
 		present(ticks, cardname, color);
 
+	// shutdown
 	munmap((void *) area, MMAP_SIZE);
+
+	shutdown_pci();
+
 	return 0;
 }

--- a/ui.c
+++ b/ui.c
@@ -76,7 +76,7 @@ static void percentage(const unsigned int y, const unsigned int w, const float p
 	attroff(A_REVERSE);
 }
 
-void present(const unsigned int ticks, const char card[], const unsigned int color) {
+void present(const unsigned int ticks, const char card[], unsigned int color) {
 
 	printf(_("Collecting data, please wait....\n"));
 
@@ -89,15 +89,13 @@ void present(const unsigned int ticks, const char card[], const unsigned int col
 	halfdelay(10);
 	curs_set(0);
 	clear();
-	if(color) {
-		start_color();
 
-		init_pair(1, COLOR_GREEN, COLOR_BLACK);
-		init_pair(2, COLOR_RED, COLOR_BLACK);
-		init_pair(3, COLOR_CYAN, COLOR_BLACK);
-		init_pair(4, COLOR_MAGENTA, COLOR_BLACK);
-		init_pair(5, COLOR_YELLOW, COLOR_BLACK);
-	}
+	start_color();
+	init_pair(1, COLOR_GREEN, COLOR_BLACK);
+	init_pair(2, COLOR_RED, COLOR_BLACK);
+	init_pair(3, COLOR_CYAN, COLOR_BLACK);
+	init_pair(4, COLOR_MAGENTA, COLOR_BLACK);
+	init_pair(5, COLOR_YELLOW, COLOR_BLACK);
 
 	const unsigned int bigh = 23;
 
@@ -233,7 +231,8 @@ void present(const unsigned int ticks, const char card[], const unsigned int col
 		refresh();
 
 		int c = getch();
-		if (c == 'q') break;
+		if (c == 'q' || c == 'Q') break;
+		if (c == 'c' || c == 'C') color = !color;
 	}
 
 	endwin();


### PR DESCRIPTION
Here's a collection of changes I made after I repeatedly kept forgetting to add -c, and then decided to run it through valgrind - sorry they're not split up!

I also have another local change that seems to make valgrind happier (~400KB -> ~20KB lost), but I don't think it's worth committing so here's the diff instead:

```
diff --git a/ui.c b/ui.c
index 3a9fa75..04e729c 100644
--- a/ui.c
+++ b/ui.c
@@ -84,7 +84,9 @@ void present(const unsigned int ticks, const char card[], unsigned int color) {
        while(!results)
                usleep(16000);
 
-       initscr();
+       SCREEN *screen = newterm(NULL, stdout, stdin);
+       set_term(screen);
+
        noecho();
        halfdelay(10);
        curs_set(0);
@@ -236,4 +238,5 @@ void present(const unsigned int ticks, const char card[], unsigned int color) {
        }
 
        endwin();
+       delscreen(screen);
 }
```