### PR TITLE
Allow unprivileged access on console (and X session with an optional libxcb)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+libradeontop_xcb.so
 radeontop
 version.h
 *.mo

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ RadeonTop
 
 View your GPU utilization, both for the total activity percent and individual blocks.
 
-Requires root rights or other permissions to /dev/mem.
+Requires access to /dev/dri/cardN files or /dev/mem (root privileges).
 
 Supported cards
 ---------------

--- a/auth.c
+++ b/auth.c
@@ -1,0 +1,31 @@
+/*
+    Copyright (C) 2016 Peter Wu <peter@lekensteyn.nl>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, version 3 of the License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "radeontop.h"
+
+void authenticate_drm(int fd) {
+	drm_magic_t magic;
+
+	/* Obtain magic for our DRM client. */
+	if (drmGetMagic(fd, &magic) < 0) {
+		return;
+	}
+
+	/* Try self-authenticate (if we are somehow the master). */
+	if (drmAuthMagic(fd, magic) == 0) {
+		return;
+	}
+}

--- a/detect.c
+++ b/detect.c
@@ -135,6 +135,7 @@ unsigned int init_pci(unsigned char bus, const unsigned char forcemem) {
 
 	use_ioctl = 0;
 	if (drm_fd >= 0) {
+		authenticate_drm(drm_fd);
 		uint32_t rreg = 0x8010;
 		use_ioctl = get_drm_value(drm_fd, RADEON_INFO_READ_REG, &rreg);
 	}

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -48,6 +48,9 @@ enum {
 #define RADEON_INFO_READ_REG 0x24
 #endif
 
+// auth.c
+void authenticate_drm(int fd);
+
 // radeontop.c
 void die(const char *why);
 int get_drm_value(int fd, unsigned request, uint32_t *out);


### PR DESCRIPTION
After these changes it is possible to run `radeontop` as unprivileged user on a desktop PC with integrated Intel graphics and an AMD GPU:
```
00:02.0 Display controller [0380]: Intel Corporation Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller [8086:0162] (rev 09)
01:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Barts LE [Radeon HD 6790] [1002:673e]
01:00.1 Audio device [0403]: Advanced Micro Devices, Inc. [AMD/ATI] Barts HDMI Audio [Radeon HD 6800 Series] [1002:aa88]
```
For hybrid graphics laptops where the first PCI device is also reported as "VGA compatible controller", it would be worth checking the vendor ID in the PCI loop too... that could be done later if it is needed.

Unprivileged vram access is made possible via DRM after authenticating, see DRI2Authenticate at
https://www.x.org/archive/X11R7.5/doc/dri2proto/dri2proto.txt
https://xcb.freedesktop.org/manual/group__XCB__DRI2__API.html
https://mail.gnome.org/archives/commits-list/2013-October/msg04520.html
https://www.mail-archive.com/mesa-dev@lists.freedesktop.org/msg112417.html