### PR TITLE
Add support for resizeable terminals

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -229,6 +229,9 @@ void present(const unsigned int ticks, const char card[], unsigned int color) {
 			if (color) attroff(COLOR_PAIR(2));
 		}
 
+		//move the cursor away to fix some resizing artifacts on some terminals
+		move(0,0);
+
 		refresh();
 
 		int c = getch();

--- a/ui.c
+++ b/ui.c
@@ -102,17 +102,18 @@ void present(const unsigned int ticks, const char card[], unsigned int color) {
 	unsigned int w, h;
 	getmaxyx(stdscr, h, w);
 
-	const unsigned int hw = w/2;
-
-	attron(A_REVERSE);
-	mvhline(0, 0, ' ', w);
-	printcenter(0, w, _("radeontop %s, running on %s, %u samples/sec"),
-			VERSION, card, 	ticks);
-	attroff(A_REVERSE);
+	unsigned int hw = w/2;
 
 	while(1) {
+		//draw the header
+		move(0,0);
+		attron(A_REVERSE);
+		mvhline(0, 0, ' ', w);
+		printcenter(0, w, _("radeontop %s, running on %s, %u samples/sec"),
+			    VERSION, card, 	ticks);
+		attroff(A_REVERSE);
 
-		move(2, 0);
+		move(1,0);
 		clrtobot();
 
 		// Again, no need to protect these. Worst that happens is a slightly
@@ -233,6 +234,11 @@ void present(const unsigned int ticks, const char card[], unsigned int color) {
 		int c = getch();
 		if (c == 'q' || c == 'Q') break;
 		if (c == 'c' || c == 'C') color = !color;
+		if (c == KEY_RESIZE){
+			getmaxyx(stdscr, h, w);
+			hw = w/2;
+			refresh();
+		}
 	}
 
 	endwin();


### PR DESCRIPTION
This is a small change to the ui code, that makes it adapt to resized terminals. It just listens to the ncurses signal to update the h, w and hw variables. It also paints the header every time.

Works quite well.