### PR TITLE
Add a build option for transparent background

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ ifeq ($(amdgpu), 1)
 	CFLAGS += -DENABLE_AMDGPU=1
 endif
 
+# add transparent background
+ifeq ($(transparent), 1)
+	CFLAGS += -DENABLE_TRANSPARENT=1
+endif
+
 ifndef plain
 ifdef debug
 	CFLAGS += -g

--- a/ui.c
+++ b/ui.c
@@ -91,11 +91,20 @@ void present(const unsigned int ticks, const char card[], unsigned int color) {
 	clear();
 
 	start_color();
+#ifdef ENABLE_TRANSPARENT
+	use_default_colors();
+	init_pair(1, COLOR_GREEN, -1);
+	init_pair(2, COLOR_RED, -1);
+	init_pair(3, COLOR_CYAN, -1);
+	init_pair(4, COLOR_MAGENTA, -1);
+	init_pair(5, COLOR_YELLOW, -1);
+#else
 	init_pair(1, COLOR_GREEN, COLOR_BLACK);
 	init_pair(2, COLOR_RED, COLOR_BLACK);
 	init_pair(3, COLOR_CYAN, COLOR_BLACK);
 	init_pair(4, COLOR_MAGENTA, COLOR_BLACK);
 	init_pair(5, COLOR_YELLOW, COLOR_BLACK);
+#endif
 
 	const unsigned int bigh = 23;
 


### PR DESCRIPTION
This PR allows the user to build the application with background transparency using `make transparent=1`.