### PR TITLE
Add bus information to dump and UI

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -28,7 +28,7 @@ static void sighandler(int sig) {
 	}
 }
 
-void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit) {
+void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit, unsigned char bus) {
 
 #ifdef ENABLE_NLS
 	// This is a data format, so disable decimal point localization
@@ -74,6 +74,8 @@ void dumpdata(const unsigned int ticks, const char file[], const unsigned int li
 
 		fprintf(f, "%llu.%llu: ", (unsigned long long) t.tv_sec,
 				(unsigned long long) t.tv_usec);
+
+		fprintf(f, "bus %02x, ", bus);
 
 		// Again, no need to protect these. Worst that happens is a slightly
 		// wrong number.

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -75,10 +75,10 @@ void collect(unsigned int *ticks);
 extern struct bits_t *results;
 
 // ui.c
-void present(const unsigned int ticks, const char card[], unsigned int color);
+void present(const unsigned int ticks, const char card[], unsigned int color, unsigned char bus);
 
 // dump.c
-void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit);
+void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit, unsigned char bus);
 
 // chips
 enum radeon_family {

--- a/radeontop.c
+++ b/radeontop.c
@@ -138,6 +138,8 @@ int main(int argc, char **argv) {
 	// init (regain privileges for bus initialization and ultimately drop them afterwards)
 	seteuid(0);
 	const unsigned int pciaddr = init_pci(bus, forcemem);
+	// after init_pci we can assume that bus exists (otherwise it would die())
+
 	setuid(getuid());
 
 	const int family = getfamily(pciaddr);
@@ -152,9 +154,9 @@ int main(int argc, char **argv) {
 	collect(&ticks);
 
 	if (dump)
-		dumpdata(ticks, dump, limit);
+		dumpdata(ticks, dump, limit, bus);
 	else
-		present(ticks, cardname, color);
+		present(ticks, cardname, color, bus);
 
 	munmap((void *) area, MMAP_SIZE);
 	return 0;

--- a/ui.c
+++ b/ui.c
@@ -76,7 +76,7 @@ static void percentage(const unsigned int y, const unsigned int w, const float p
 	attroff(A_REVERSE);
 }
 
-void present(const unsigned int ticks, const char card[], unsigned int color) {
+void present(const unsigned int ticks, const char card[], unsigned int color, unsigned char bus) {
 
 	printf(_("Collecting data, please wait....\n"));
 
@@ -114,8 +114,8 @@ void present(const unsigned int ticks, const char card[], unsigned int color) {
 		move(0,0);
 		attron(A_REVERSE);
 		mvhline(0, 0, ' ', w);
-		printcenter(0, w, _("radeontop %s, running on %s, %u samples/sec"),
-			    VERSION, card, 	ticks);
+		printcenter(0, w, _("radeontop %s, running on %s bus %02x, %u samples/sec"),
+			    VERSION, card, bus, ticks);
 		attroff(A_REVERSE);
 
 		move(1,0);


### PR DESCRIPTION
This change adds the bus id (in hex) to both the dump as well as the radeontop UI.

Hex output allows for easy comparison of the bus id in radeontop with the bus id in other tools like lspci.

Fixes #63 