### PR TITLE
add redefinition guard around _GNU_SOURCE

### DIFF
--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -17,7 +17,9 @@
 #ifndef RADEONTOP_H
 #define RADEONTOP_H
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "version.h"
 #include "gettext.h"


### PR DESCRIPTION
`pkg-config --cflags ncurses` spits out `-D_GNU_SOURCE` on my platform which results in GCC warnings.