### PR TITLE
Add --dump-interval command-line option

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -30,7 +30,7 @@ static void sighandler(int sig) {
 }
 
 void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit,
-		const unsigned char bus) {
+		const unsigned char bus, const unsigned int dumpinterval) {
 
 #ifdef ENABLE_NLS
 	// This is a data format, so disable decimal point localization
@@ -81,23 +81,24 @@ void dumpdata(const unsigned int ticks, const char file[], const unsigned int li
 
 		// Again, no need to protect these. Worst that happens is a slightly
 		// wrong number.
-		float ee = 100.0 * (float) results->ee / ticks;
-		float vgt = 100.0 * (float) results->vgt / ticks;
-		float gui = 100.0 * (float) results->gui / ticks;
-		float ta = 100.0 * (float) results->ta / ticks;
-		float tc = 100.0 * (float) results->tc / ticks;
-		float sx = 100.0 * (float) results->sx / ticks;
-		float sh = 100.0 * (float) results->sh / ticks;
-		float spi = 100.0 * (float) results->spi / ticks;
-		float smx = 100.0 * (float) results->smx / ticks;
-		float sc = 100.0 * (float) results->sc / ticks;
-		float pa = 100.0 * (float) results->pa / ticks;
-		float db = 100.0 * (float) results->db / ticks;
-		float cr = 100.0 * (float) results->cr / ticks;
-		float cb = 100.0 * (float) results->cb / ticks;
-		float vram = 100.0 * (float) results->vram / vramsize;
+		float k = 1.0f / ticks / dumpinterval;
+		float ee = 100 * results->ee * k;
+		float vgt = 100 * results->vgt * k;
+		float gui = 100 * results->gui * k;
+		float ta = 100 * results->ta * k;
+		float tc = 100 * results->tc * k;
+		float sx = 100 * results->sx * k;
+		float sh = 100 * results->sh * k;
+		float spi = 100 * results->spi * k;
+		float smx = 100 * results->smx * k;
+		float sc = 100 * results->sc * k;
+		float pa = 100 * results->pa * k;
+		float db = 100 * results->db * k;
+		float cr = 100 * results->cr * k;
+		float cb = 100 * results->cb * k;
+		float vram = 100.0f * results->vram / vramsize;
 		float vrammb = results->vram / 1024.0f / 1024.0f;
-		float gtt = 100.0 * (float) results->gtt / gttsize;
+		float gtt = 100.0f * results->gtt / gttsize;
 		float gttmb = results->gtt / 1024.0f / 1024.0f;
 
 		fprintf(f, "gpu %.2f%%, ", gui);
@@ -139,7 +140,7 @@ void dumpdata(const unsigned int ticks, const char file[], const unsigned int li
 
 		// No sleeping on the last line.
 		if (!limit || count > 1)
-			sleep(1);
+			sleep(dumpinterval);
 	}
 
 	fflush(f);

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -73,15 +73,15 @@ unsigned long long getvram();
 unsigned long long getgtt();
 
 // ticks.c
-void collect(unsigned int *ticks);
+void collect(unsigned int ticks, unsigned int dumpinterval);
 
 extern struct bits_t *results;
 
 // ui.c
-void present(const unsigned int ticks, const char card[], unsigned int color, const unsigned char bus);
+void present(const unsigned int ticks, const char card[], unsigned int color, const unsigned char bus, const unsigned int dumpinterval);
 
 // dump.c
-void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit, const unsigned char bus);
+void dumpdata(const unsigned int ticks, const char file[], const unsigned int limit, const unsigned char bus, const unsigned int dumpinterval);
 
 // chips
 enum radeon_family {

--- a/radeontop.c
+++ b/radeontop.c
@@ -31,19 +31,20 @@ static void version() {
 	exit(1);
 }
 
-static void help(const char * const me, const unsigned int ticks) {
+static void help(const char * const me, const unsigned int ticks, const unsigned int dumpinterval) {
 	printf(_("\n\tRadeonTop for R600 and above.\n\n"
-		"\tUsage: %s [-ch] [-b bus] [-d file] [-l limit] [-t ticks]\n\n"
+		"\tUsage: %s [-ch] [-b bus] [-d file] [-i seconds] [-l limit] [-t ticks]\n\n"
 		"-b --bus 3		Pick card from this PCI bus (hexadecimal)\n"
 		"-c --color		Enable colors\n"
 		"-d --dump file		Dump data to this file, - for stdout\n"
+		"-i --dump-interval 1	Number of seconds between dumps (default %u)\n"
 		"-l --limit 3		Quit after dumping N lines, default forever\n"
 		"-m --mem		Force the /dev/mem path, for the proprietary driver\n"
 		"-t --ticks 50		Samples per second (default %u)\n"
 		"\n"
 		"-h --help		Show this help\n"
 		"-v --version		Show the version\n"),
-		me, ticks);
+		me, dumpinterval, ticks);
 	die("");
 }
 
@@ -77,11 +78,15 @@ int main(int argc, char **argv) {
 	// Temporarily drop privileges to do option parsing, etc.
 	seteuid(getuid());
 
-	unsigned int ticks = 120;
+	const unsigned int default_ticks = 120;
+	const unsigned int default_dumpinterval = 1;
+
+	unsigned int ticks = default_ticks;
 	unsigned char color = 0;
 	unsigned char bus = 0, forcemem = 0;
 	unsigned int limit = 0;
 	char *dump = NULL;
+	unsigned int dumpinterval = default_dumpinterval;
 
 	// Translations
 #ifdef ENABLE_NLS
@@ -95,6 +100,7 @@ int main(int argc, char **argv) {
 		{"bus", 1, 0, 'b'},
 		{"color", 0, 0, 'c'},
 		{"dump", 1, 0, 'd'},
+		{"dump-interval", 1, 0, 'i'},
 		{"help", 0, 0, 'h'},
 		{"limit", 1, 0, 'l'},
 		{"mem", 0, 0, 'm'},
@@ -104,13 +110,13 @@ int main(int argc, char **argv) {
 	};
 
 	while (1) {
-		int c = getopt_long(argc, argv, "b:cd:hl:mt:v", opts, NULL);
+		int c = getopt_long(argc, argv, "b:cd:hi:l:mt:v", opts, NULL);
 		if (c == -1) break;
 
 		switch(c) {
 			case 'h':
 			case '?':
-				help(argv[0], ticks);
+				help(argv[0], default_ticks, default_dumpinterval);
 			break;
 			case 't':
 				ticks = atoi(optarg);
@@ -133,6 +139,11 @@ int main(int argc, char **argv) {
 			case 'd':
 				dump = optarg;
 			break;
+			case 'i':
+				dumpinterval = atoi(optarg);
+				if(dumpinterval < 1)
+					dumpinterval = 1;
+			break;
 		}
 	}
 
@@ -152,12 +163,12 @@ int main(int argc, char **argv) {
 	initbits(family);
 
 	// runtime
-	collect(&ticks);
+	collect(ticks, dumpinterval);
 
 	if (dump)
-		dumpdata(ticks, dump, limit, bus);
+		dumpdata(ticks, dump, limit, bus, dumpinterval);
 	else
-		present(ticks, cardname, color, bus);
+		present(ticks, cardname, color, bus, dumpinterval);
 
 	munmap((void *) area, MMAP_SIZE);
 	return 0;

--- a/ui.c
+++ b/ui.c
@@ -77,7 +77,7 @@ static void percentage(const unsigned int y, const unsigned int w, const float p
 }
 
 void present(const unsigned int ticks, const char card[], unsigned int color,
-		const unsigned char bus) {
+		const unsigned char bus, const unsigned int dumpinterval) {
 
 	printf(_("Collecting data, please wait....\n"));
 
@@ -124,24 +124,25 @@ void present(const unsigned int ticks, const char card[], unsigned int color,
 
 		// Again, no need to protect these. Worst that happens is a slightly
 		// wrong number.
-		float ee = 100.0 * (float) results->ee / ticks;
-		float vgt = 100.0 * (float) results->vgt / ticks;
-		float gui = 100.0 * (float) results->gui / ticks;
-		float ta = 100.0 * (float) results->ta / ticks;
-		float tc = 100.0 * (float) results->tc / ticks;
-		float sx = 100.0 * (float) results->sx / ticks;
-		float sh = 100.0 * (float) results->sh / ticks;
-		float spi = 100.0 * (float) results->spi / ticks;
-		float smx = 100.0 * (float) results->smx / ticks;
-		float sc = 100.0 * (float) results->sc / ticks;
-		float pa = 100.0 * (float) results->pa / ticks;
-		float db = 100.0 * (float) results->db / ticks;
-		float cr = 100.0 * (float) results->cr / ticks;
-		float cb = 100.0 * (float) results->cb / ticks;
-		float vram = 100.0 * (float) results->vram / vramsize;
+		float k = 1.0f / ticks / dumpinterval;
+		float ee = 100 * results->ee * k;
+		float vgt = 100 * results->vgt * k;
+		float gui = 100 * results->gui * k;
+		float ta = 100 * results->ta * k;
+		float tc = 100 * results->tc * k;
+		float sx = 100 * results->sx * k;
+		float sh = 100 * results->sh * k;
+		float spi = 100 * results->spi * k;
+		float smx = 100 * results->smx * k;
+		float sc = 100 * results->sc * k;
+		float pa = 100 * results->pa * k;
+		float db = 100 * results->db * k;
+		float cr = 100 * results->cr * k;
+		float cb = 100 * results->cb * k;
+		float vram = 100.0f * results->vram / vramsize;
 		float vrammb = results->vram / 1024.0f / 1024.0f;
 		float vramsizemb = vramsize / 1024.0f / 1024.0f;
-		float gtt = 100.0 * (float) results->gtt / gttsize;
+		float gtt = 100.0f * results->gtt / gttsize;
 		float gttmb = results->gtt / 1024.0f / 1024.0f;
 		float gttsizemb = gttsize / 1024.0f / 1024.0f;
 


### PR DESCRIPTION
This patch adds --dump-interval (short option: -i) command-line option.
It is useful when one wants to run radeontop in the background to
continuously collect GPU statistics and wants to save disk space.
A setting such as "-i 60" logs 60 times smaller amount of data than the
default dump interval of 1 second.

The patch also slightly optimizes the computation of averages by
avoiding superfluous floating-point conversions and by substituting
divisions with multiplications by a reciprocal.