### PR TITLE
Fix bus ID with gpu autodetection

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2012 Lauri Kasanen
+    Copyright (C) 2018 Genesis Cloud Ltd.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,12 +25,8 @@ unsigned long long gttsize;
 int drm_fd = -1;
 char drm_name[10] = ""; // should be radeon or amdgpu
 
-unsigned int init_pci(unsigned char bus, const unsigned char forcemem) {
-
-	int ret = pci_system_init();
-	if (ret)
-		die(_("Failed to init pciaccess"));
-
+struct pci_device * findGPUDevice(const unsigned char bus) {
+	struct pci_device *dev;
 	struct pci_id_match match;
 
 	match.vendor_id = 0x1002;
@@ -41,16 +38,12 @@ unsigned int init_pci(unsigned char bus, const unsigned char forcemem) {
 	match.match_data = 0;
 
 	struct pci_device_iterator *iter = pci_id_match_iterator_create(&match);
-	struct pci_device *dev = NULL;
-	char busid[32];
 
 	while ((dev = pci_device_next(iter))) {
 		pci_device_probe(dev);
 		if ((dev->device_class & 0x00ffff00) != 0x00030000 &&
 			(dev->device_class & 0x00ffff00) != 0x00038000)
 			continue;
-		snprintf(busid, sizeof(busid), "pci:%04x:%02x:%02x.%u",
-				dev->domain, dev->bus, dev->dev, dev->func);
 		if (!bus || bus == dev->bus)
 			break;
 	}
@@ -59,6 +52,21 @@ unsigned int init_pci(unsigned char bus, const unsigned char forcemem) {
 
 	if (!dev)
 		die(_("Can't find Radeon cards"));
+
+	return dev;
+}
+
+unsigned int init_pci(unsigned char bus, const unsigned char forcemem) {
+
+	int ret = pci_system_init();
+	if (ret)
+		die(_("Failed to init pciaccess"));
+
+	struct pci_device * const dev = findGPUDevice(bus);
+
+	char busid[32];
+	snprintf(busid, sizeof(busid), "pci:%04x:%02x:%02x.%u",
+			 dev->domain, dev->bus, dev->dev, dev->func);
 
 	const unsigned int device_id = dev->device_id;
 	int reg = 2;

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -66,7 +66,7 @@ extern const void *area;
 extern int use_ioctl;
 
 // detect.c
-unsigned int init_pci(unsigned char bus, const unsigned char forcemem);
+struct pci_device init_pci(unsigned char bus, const unsigned char forcemem);
 int getfamily(unsigned int id);
 void initbits(int fam);
 unsigned long long getvram();


### PR DESCRIPTION
Follow-up of #64 

When no bus is specified via `-b xx`, the bus shows as `00` in both the dump as well as the UI as it is never being set properly.

This PR basically returns (i.e. copies) the whole `pci_device` from `init_pci()` to make it fully accessible in `main()`. This allows to print and forward even more information from the PCI device in the future.

Any opinions?