### PR TITLE
Makefile: Add a soname to libradeontop_xcb.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ifeq ($(xcb), 1)
 all: $(xcblib)
 
 $(xcblib): auth_xcb.c $(wildcard include/*.h) $(verh)
-	$(CC) -shared -fPIC -o $@ $< $(CFLAGS) $(LDFLAGS) $(xcb_LIBS)
+	$(CC) -shared -fPIC -Wl,-soname,$@ -o $@ $< $(CFLAGS) $(LDFLAGS) $(xcb_LIBS)
 endif
 
 $(obj): $(wildcard include/*.h) $(verh)


### PR DESCRIPTION
The shared libradeontop_xcb.so is lacking a soname. This triggers a QA notice in Gentoo and it does not hurt to have one.