### PR TITLE
getver.sh: Only use git if its a git repo.

### DIFF
--- a/getver.sh
+++ b/getver.sh
@@ -2,7 +2,9 @@
 
 ver=unknown
 
-[ -n "`which git`" ] && ver=`git describe`
+if [ -n "`which git`" ] && git rev-parse HEAD 2>/dev/null; then
+  ver=`git describe`
+fi
 
 cat > include/version.h << EOF
 #ifndef VER_H


### PR DESCRIPTION
This will be helpful for people building from release tarballs where `git` may be in the user's `$PATH`, but it might not actually be inside a git directory. Instead of printing a git error it will just use `ver=unknown`.