### PR TITLE
amdgpu support for GRBM readings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ endif
 
 ifeq ($(amdgpu), 1)
 	CFLAGS += -DENABLE_AMDGPU=1
+	LIBS += $(shell pkg-config --libs libdrm_amdgpu)
 endif
 
 ifndef plain

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Build options can be specified to having the following variables being set to "1
     nostrip disable stripping, default off
     plain   apply neither gcc's -g nor -s.
     xcb     enable libxcb to run unprivileged in Xorg, default on
-    amdgpu  enable amdgpu VRAM size and usage reporting, default off (requires libdrm >= 2.4.77)
+    amdgpu  enable amdgpu VRAM size and usage reporting, default auto (requires libdrm >= 2.4.77)
 
 
 Example:
 
     make amdgpu=1 xcb=1
 
-This will build radeontop with amdgpu VRAM reporting and xcb support.
+This will build radeontop with amdgpu reporting and xcb support.

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -59,16 +59,13 @@ void authenticate_drm(int fd);
 
 // radeontop.c
 void die(const char *why);
-int get_drm_value(int fd, unsigned request, uint32_t *out);
-unsigned int readgrbm();
-
-extern const void *area;
-extern int use_ioctl;
 
 // detect.c
 void init_pci(unsigned char *bus, unsigned int *device_id, const unsigned char forcemem);
 int getfamily(unsigned int id);
 void initbits(int fam);
+void cleanup();
+unsigned int readgrbm();
 unsigned long long getvram();
 unsigned long long getgtt();
 unsigned long long getmclk();

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -38,9 +38,6 @@
 #include <locale.h>
 #include <xf86drm.h>
 #include <radeon_drm.h>
-#ifdef ENABLE_AMDGPU
-#include <amdgpu_drm.h>
-#endif
 
 enum {
 	GRBM_STATUS = 0x8010,

--- a/radeontop.c
+++ b/radeontop.c
@@ -18,9 +18,6 @@
 #include "radeontop.h"
 #include <getopt.h>
 
-const void *area;
-int use_ioctl;
-
 void die(const char * const why) {
 	puts(why);
 	exit(1);
@@ -46,32 +43,6 @@ static void help(const char * const me, const unsigned int ticks, const unsigned
 		"-v --version		Show the version\n"),
 		me, dumpinterval, ticks);
 	die("");
-}
-
-int get_drm_value(int fd, unsigned request, uint32_t *out) {
-	struct drm_radeon_info info;
-	int retval;
-
-	memset(&info, 0, sizeof(info));
-
-	info.value = (unsigned long)out;
-	info.request = request;
-
-	retval = drmCommandWriteRead(fd, DRM_RADEON_INFO, &info, sizeof(info));
-	return !retval;
-}
-
-unsigned int readgrbm() {
-
-	if (use_ioctl) {
-		uint32_t reg = 0x8010;
-		get_drm_value(drm_fd, RADEON_INFO_READ_REG, &reg);
-		return reg;
-	} else {
-		const void *ptr = (const char *) area + 0x10;
-		const unsigned int *inta = ptr;
-		return *inta;
-	}
 }
 
 int main(int argc, char **argv) {
@@ -171,6 +142,6 @@ int main(int argc, char **argv) {
 	else
 		present(ticks, cardname, color, bus, dumpinterval);
 
-	munmap((void *) area, MMAP_SIZE);
+	cleanup();
 	return 0;
 }


### PR DESCRIPTION
New kernels can be configured with secure boot lockdown on /dev/mem, thus radeontop is no more running on the amdgpu driver. This patch set adds the support for readings GRBM via drm on amdgpu.

It needs some refinement, but it's seems to me a good starting point. It is tested on KAVERI with full opensource stack with drm and /dev/mem access. No tests was made with closed source drivers nor radeon drm driver.

Comments and suggestions are appreciated :)