### PR TITLE
Clock frequency support for radeon and APUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ xcb ?= 1
 
 bin = radeontop
 xcblib = libradeontop_xcb.so
-src = $(filter-out auth_xcb.c,$(wildcard *.c))
-obj = $(src:.c=.o)
+src = $(filter-out amdgpu.c auth_xcb.c,$(wildcard *.c))
 verh = include/version.h
 
 CFLAGS_SECTIONED = -ffunction-sections -fdata-sections
@@ -52,6 +51,7 @@ else
 endif
 
 ifeq ($(amdgpu), 1)
+	src += amdgpu.c
 	CFLAGS += -DENABLE_AMDGPU=1
 	LIBS += $(shell pkg-config --libs libdrm_amdgpu)
 
@@ -68,6 +68,7 @@ else ifndef nostrip
 endif
 endif
 
+obj = $(src:.c=.o)
 LDFLAGS ?= -Wl,-O1
 LDFLAGS += $(LDFLAGS_SECTIONED)
 LIBS += $(shell pkg-config --libs pciaccess)

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
 #	nostrip	disable stripping, default off
 #	plain	apply neither -g nor -s.
 #	xcb	enable libxcb to run unprivileged in Xorg, default on
-#	amdgpu	enable amdgpu VRAM size and usage reporting, default auto
-#		it requires libdrm >= 2.4.77
+#	amdgpu	enable amdgpu usage reporting, default auto
+#		it requires libdrm >= 2.4.63
 
 PREFIX ?= /usr
 INSTALL ?= install

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 RadeonTop
 =========
 
-View your GPU utilization, both for the total activity percent and individual blocks.
+View your GPU utilization, both for the total activity percent and
+individual blocks.
 
 Requires access to /dev/dri/cardN files or /dev/mem (root privileges).
 
@@ -11,9 +12,8 @@ Supported cards
 R600 and up, even Southern Islands should work fine.
 Works with both the open drivers and AMD Catalyst.
 
-For the amdgpu driver, only the mem path is currently supported -
-for those cards, this means radeontop won't run on the default Ubuntu
-kernels that block /dev/mem.
+For the Catalyst driver, only the mem path is currently supported - this
+means it won't run on the default Ubuntu kernels that block /dev/mem.
 
 The total GPU utilization is also valid for OpenCL loads; the other blocks
 are only useful in GL loads.
@@ -78,7 +78,7 @@ Build options can be specified to having the following variables being set to "1
     nostrip disable stripping, default off
     plain   apply neither gcc's -g nor -s.
     xcb     enable libxcb to run unprivileged in Xorg, default on
-    amdgpu  enable amdgpu VRAM size and usage reporting, default auto (requires libdrm >= 2.4.77)
+    amdgpu  enable amdgpu usage reporting, default auto (requires libdrm >= 2.4.63)
 
 
 Example:

--- a/amdgpu.c
+++ b/amdgpu.c
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2012 Lauri Kasanen
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, version 3 of the License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "radeontop.h"
+#include <libdrm/amdgpu_drm.h>
+#include <libdrm/amdgpu.h>
+
+amdgpu_device_handle amdgpu_dev;
+
+static int getgrbm_amdgpu(uint32_t *out) {
+	return amdgpu_read_mm_registers(amdgpu_dev, GRBM_STATUS / 4, 1,
+					0xffffffff, 0, out);
+}
+
+static int getvram_amdgpu(uint64_t *out) {
+	return amdgpu_query_info(amdgpu_dev, AMDGPU_INFO_VRAM_USAGE,
+				sizeof(uint64_t), out);
+}
+
+static int getgtt_amdgpu(uint64_t *out) {
+	return amdgpu_query_info(amdgpu_dev, AMDGPU_INFO_GTT_USAGE,
+				sizeof(uint64_t), out);
+}
+
+#ifdef HAS_AMDGPU_QUERY_SENSOR_INFO
+static int getsclk_amdgpu(uint32_t *out) {
+	return amdgpu_query_sensor_info(amdgpu_dev, AMDGPU_INFO_SENSOR_GFX_SCLK,
+		sizeof(uint32_t), out);
+}
+
+static int getmclk_amdgpu(uint32_t *out) {
+	return amdgpu_query_sensor_info(amdgpu_dev, AMDGPU_INFO_SENSOR_GFX_MCLK,
+		sizeof(uint32_t), out);
+}
+#endif
+
+void init_amdgpu(int fd) {
+	uint32_t drm_major, drm_minor;
+	int ret;
+
+	if (amdgpu_device_initialize(fd, &drm_major, &drm_minor, &amdgpu_dev))
+		die(_("Can't initialize amdgpu driver"));
+
+	getgrbm = getgrbm_amdgpu;
+
+#ifdef HAS_AMDGPU_QUERY_SENSOR_INFO
+	struct amdgpu_gpu_info gpu;
+
+	amdgpu_query_gpu_info(amdgpu_dev, &gpu);
+	sclk_max = gpu.max_engine_clk;
+	mclk_max = gpu.max_memory_clk;
+	getsclk = getsclk_amdgpu;
+	getmclk = getmclk_amdgpu;
+#else
+	printf(_("amdgpu DRM driver is used, but clock reporting is not enabled\n"));
+#endif
+
+	struct drm_amdgpu_info_vram_gtt vram_gtt;
+
+	if ((ret = amdgpu_query_info(amdgpu_dev, AMDGPU_INFO_VRAM_GTT,
+				sizeof(vram_gtt), &vram_gtt))) {
+		printf(_("Failed to get VRAM size, error %d\n"), ret);
+		return;
+	}
+
+	vramsize = vram_gtt.vram_size;
+	gttsize = vram_gtt.gtt_size;
+	getvram = getvram_amdgpu;
+	getgtt = getgtt_amdgpu;
+}
+
+void cleanup_amdgpu() {
+	if (amdgpu_dev)
+		amdgpu_device_deinitialize(amdgpu_dev);
+}

--- a/detect.c
+++ b/detect.c
@@ -72,34 +72,29 @@ struct pci_device * findGPUDevice(const unsigned char bus) {
 	return dev;
 }
 
-static int getgrbm_radeon(uint32_t *out) {
+static int radeon_get_drm_value(int fd, unsigned request, uint32_t *out) {
 	struct drm_radeon_info info;
 
 	memset(&info, 0, sizeof(info));
+	info.value = (unsigned long) out;
+	info.request = request;
+
+	return drmCommandWriteRead(fd, DRM_RADEON_INFO, &info, sizeof(info));
+}
+
+static int getgrbm_radeon(uint32_t *out) {
 	*out = GRBM_STATUS;
-
-	info.value = (unsigned long)out;
-	info.request = RADEON_INFO_READ_REG;
-
-	return drmCommandWriteRead(drm_fd, DRM_RADEON_INFO, &info, sizeof(info));
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_READ_REG, out);
 }
 
 static int getvram_radeon(uint64_t *out) {
-	struct drm_radeon_info info;
-	memset(&info, 0, sizeof(info));
-	info.value = (unsigned long) out;
-	info.request = RADEON_INFO_VRAM_USAGE;
-
-	return drmCommandWriteRead(drm_fd, DRM_RADEON_INFO, &info, sizeof(info));
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_VRAM_USAGE,
+				(uint32_t *) out);
 }
 
 static int getgtt_radeon(uint64_t *out) {
-	struct drm_radeon_info info;
-	memset(&info, 0, sizeof(info));
-	info.value = (unsigned long) out;
-	info.request = RADEON_INFO_GTT_USAGE;
-
-	return drmCommandWriteRead(drm_fd, DRM_RADEON_INFO, &info, sizeof(info));
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_GTT_USAGE,
+				(uint32_t *) out);
 }
 
 #ifdef ENABLE_AMDGPU

--- a/detect.c
+++ b/detect.c
@@ -150,6 +150,46 @@ static int getmclk_amdgpu(uint32_t *out) {
 		sizeof(uint32_t), out);
 }
 #endif
+
+void init_amdgpu(int fd) {
+	uint32_t drm_major, drm_minor;
+	int ret;
+
+	if (amdgpu_device_initialize(fd, &drm_major, &drm_minor, &amdgpu_dev))
+		die(_("Can't initialize amdgpu driver"));
+
+	getgrbm = getgrbm_amdgpu;
+
+#ifdef HAS_AMDGPU_QUERY_SENSOR_INFO
+	struct amdgpu_gpu_info gpu;
+
+	amdgpu_query_gpu_info(amdgpu_dev, &gpu);
+	sclk_max = gpu.max_engine_clk;
+	mclk_max = gpu.max_memory_clk;
+	getsclk = getsclk_amdgpu;
+	getmclk = getmclk_amdgpu;
+#else
+	printf(_("amdgpu DRM driver is used, but clock reporting is not enabled\n"));
+#endif
+
+	struct drm_amdgpu_info_vram_gtt vram_gtt;
+
+	if ((ret = amdgpu_query_info(amdgpu_dev, AMDGPU_INFO_VRAM_GTT,
+				sizeof(vram_gtt), &vram_gtt))) {
+		printf(_("Failed to get VRAM size, error %d\n"), ret);
+		return;
+	}
+
+	vramsize = vram_gtt.vram_size;
+	gttsize = vram_gtt.gtt_size;
+	getvram = getvram_amdgpu;
+	getgtt = getgtt_amdgpu;
+}
+
+void cleanup_amdgpu() {
+	if (amdgpu_dev)
+		amdgpu_device_deinitialize(amdgpu_dev);
+}
 #endif
 
 static int getgrbm_memory(uint32_t *out) {
@@ -207,15 +247,7 @@ void init_pci(unsigned char *bus, unsigned int *device_id, const unsigned char f
 			init_radeon(drm_fd);
 		else if (strcmp(drm_name, "amdgpu") == 0) {
 #ifdef ENABLE_AMDGPU
-			uint32_t maj, min;
-
-			if (amdgpu_device_initialize(drm_fd, &maj, &min,
-						&amdgpu_dev))
-				die(_("Can't initialize amdgpu driver"));
-
-			getgrbm = getgrbm_amdgpu;
-			getvram = getvram_amdgpu;
-			getgtt = getgtt_amdgpu;
+			init_amdgpu(drm_fd);
 #else
 			printf(_("amdgpu DRM driver is used, but support is not compiled in\n"));
 #endif
@@ -254,41 +286,9 @@ void init_pci(unsigned char *bus, unsigned int *device_id, const unsigned char f
 			ver->version_patchlevel,
 			ver->name);*/
 
-		if (strcmp(drm_name, "amdgpu") == 0) {
-#ifdef HAS_AMDGPU_QUERY_SENSOR_INFO
-			struct amdgpu_gpu_info gpu = {};
-			ret = amdgpu_query_gpu_info(amdgpu_dev, &gpu);
-
-			if (ret == 0) {
-				mclk_max = gpu.max_memory_clk;
-				sclk_max = gpu.max_engine_clk;
-				getsclk = getsclk_amdgpu;
-				getmclk = getmclk_amdgpu;
-			}
-#else
-			printf(_("amdgpu DRM driver is used, but clock reporting is not enabled\n"));
-#endif
-		}
-
 		// No version indicator, so we need to test once
 		// We use different codepaths for radeon and amdgpu
 		// We store vram_size and check below if the ret value is sane
-		if (strcmp(drm_name, "amdgpu") == 0) {
-#ifdef ENABLE_AMDGPU
-			struct drm_amdgpu_info_vram_gtt vram_gtt = {};
-			ret = amdgpu_query_info(amdgpu_dev,
-						AMDGPU_INFO_VRAM_GTT,
-						sizeof(vram_gtt), &vram_gtt);
-			vramsize = vram_gtt.vram_size;
-			gttsize = vram_gtt.gtt_size;
-#endif
-		}
-		if (ret) {
-			printf(_("Failed to get VRAM size, error %d\n"),
-				ret);
-			goto out;
-		}
-
 		uint64_t out64;
 
 		ret = getvram(&out64);
@@ -319,7 +319,7 @@ void cleanup() {
 	munmap((void *) area, MMAP_SIZE);
 
 #ifdef ENABLE_AMDGPU
-	amdgpu_device_deinitialize(amdgpu_dev);
+	cleanup_amdgpu();
 #endif
 }
 

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -38,6 +38,7 @@
 #include <locale.h>
 #include <xf86drm.h>
 #include <radeon_drm.h>
+#include <stdint.h>
 
 enum {
 	GRBM_STATUS = 0x8010,
@@ -62,11 +63,12 @@ void init_pci(unsigned char *bus, unsigned int *device_id, const unsigned char f
 int getfamily(unsigned int id);
 void initbits(int fam);
 void cleanup();
-unsigned int readgrbm();
-unsigned long long getvram();
-unsigned long long getgtt();
-unsigned long long getmclk();
-unsigned long long getsclk();
+
+extern int (*getgrbm)(uint32_t *out);
+extern int (*getvram)(uint64_t *out);
+extern int (*getgtt)(uint64_t *out);
+extern int (*getsclk)(uint32_t *out);
+extern int (*getmclk)(uint32_t *out);
 
 // ticks.c
 void collect(unsigned int ticks, unsigned int dumpinterval);
@@ -151,17 +153,17 @@ struct bits_t {
 	unsigned int db;
 	unsigned int cb;
 	unsigned int cr;
-	unsigned long long vram;
-	unsigned long long gtt;
-	unsigned long long mclk;
-	unsigned long long sclk;
+	uint64_t vram;
+	uint64_t gtt;
+	unsigned int sclk;
+	unsigned int mclk;
 };
 
 extern struct bits_t bits;
-extern unsigned long long vramsize;
-extern unsigned long long gttsize;
-extern unsigned long long mclk_max;
-extern unsigned long long sclk_max;
+extern uint64_t vramsize;
+extern uint64_t gttsize;
+extern unsigned int sclk_max;
+extern unsigned int mclk_max;
 extern int drm_fd;
 
 #endif

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -37,7 +37,6 @@
 #include <signal.h>
 #include <locale.h>
 #include <xf86drm.h>
-#include <radeon_drm.h>
 #include <stdint.h>
 
 enum {
@@ -165,5 +164,12 @@ extern uint64_t gttsize;
 extern unsigned int sclk_max;
 extern unsigned int mclk_max;
 extern int drm_fd;
+
+// radeon.c
+void init_radeon(int fd);
+
+// amdgpu.c
+void init_amdgpu(int fd);
+void cleanup_amdgpu();
 
 #endif

--- a/radeon.c
+++ b/radeon.c
@@ -96,8 +96,8 @@ void init_radeon(int fd) {
 
 		if (!(ret = getmclk_radeon(&out32)))
 			getmclk = getmclk_radeon;
-		else	// no APU flag on radeon
-			drmError(ret, _("Failed to get memory clock (ignore this on APUs)"));
+		else
+			drmError(ret, _("Failed to get memory clock"));
 	} else
 		fprintf(stderr, _("GPU usage reporting is disabled (radeon kernel driver 2.42.0 required)\n"));
 #else

--- a/radeon.c
+++ b/radeon.c
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2012 Lauri Kasanen
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, version 3 of the License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "radeontop.h"
+#include <radeon_drm.h>
+#include <xf86drm.h>
+
+int drm_fd;
+
+static int radeon_get_drm_value(int fd, unsigned request, uint32_t *out) {
+	struct drm_radeon_info info;
+
+	memset(&info, 0, sizeof(info));
+	info.value = (unsigned long) out;
+	info.request = request;
+
+	return drmCommandWriteRead(fd, DRM_RADEON_INFO, &info, sizeof(info));
+}
+
+static int getgrbm_radeon(uint32_t *out) {
+	*out = GRBM_STATUS;
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_READ_REG, out);
+}
+
+static int getvram_radeon(uint64_t *out) {
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_VRAM_USAGE,
+				(uint32_t *) out);
+}
+
+static int getgtt_radeon(uint64_t *out) {
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_GTT_USAGE,
+				(uint32_t *) out);
+}
+
+void init_radeon(int fd) {
+	int drm_major, drm_minor, ret;
+	drmVersionPtr ver = drmGetVersion(fd);
+
+	drm_fd = fd;
+	drm_major = ver->version_major;
+	drm_minor = ver->version_minor;
+	drmFreeVersion(ver);
+	getgrbm = getgrbm_radeon;
+
+	if (drm_major > 2 || (drm_major == 2 && drm_minor >= 36)) {
+		struct drm_radeon_gem_info gem;
+
+		if ((ret = drmCommandWriteRead(fd, DRM_RADEON_GEM_INFO,
+					 &gem, sizeof(gem)))) {
+			printf(_("Failed to get VRAM size, error %d\n"), ret);
+			return;
+		}
+
+		vramsize = gem.vram_size;
+		gttsize = gem.gart_size;
+		getvram = getvram_radeon;
+		getgtt = getgtt_radeon;
+	} else
+		printf(_("Kernel too old for VRAM reporting.\n"));
+}

--- a/radeon.c
+++ b/radeon.c
@@ -35,6 +35,14 @@ static int getgrbm_radeon(uint32_t *out) {
 	*out = GRBM_STATUS;
 	return radeon_get_drm_value(drm_fd, RADEON_INFO_READ_REG, out);
 }
+
+static int getsclk_radeon(uint32_t *out) {
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_CURRENT_GPU_SCLK, out);
+}
+
+static int getmclk_radeon(uint32_t *out) {
+	return radeon_get_drm_value(drm_fd, RADEON_INFO_CURRENT_GPU_MCLK, out);
+}
 #endif
 
 #ifdef RADEON_INFO_VRAM_USAGE
@@ -74,6 +82,22 @@ void init_radeon(int fd) {
 			getgrbm = getgrbm_radeon;
 		else
 			drmError(ret, _("Failed to get GPU usage"));
+
+		if ((ret = radeon_get_drm_value(drm_fd, RADEON_INFO_MAX_SCLK,
+						&sclk_max)))
+			drmError(ret, _("Failed to get maximum shader clock"));
+
+		mclk_max = 0;	// no max memory clock info on radeon
+
+		if (!(ret = getsclk_radeon(&out32)))
+			getsclk = getsclk_radeon;
+		else
+			drmError(ret, _("Failed to get shader clock"));
+
+		if (!(ret = getmclk_radeon(&out32)))
+			getmclk = getmclk_radeon;
+		else	// no APU flag on radeon
+			drmError(ret, _("Failed to get memory clock (ignore this on APUs)"));
 	} else
 		fprintf(stderr, _("GPU usage reporting is disabled (radeon kernel driver 2.42.0 required)\n"));
 #else

--- a/radeontop.1
+++ b/radeontop.1
@@ -31,7 +31,7 @@
 radeontop \- tool to show GPU utilization
 .SH "SYNOPSIS"
 .sp
-\fBradeontop [\-chv] [\-b \fR\fB\fIbus\fR\fR\fB] [\-d \fR\fB\fIfile\fR\fR\fB] [\-l \fR\fB\fIlimit\fR\fR\fB] [\-i \fR\fB\fIsecs\fR\fR\fB] [\-t \fR\fB\fIticks\fR\fR\fB]\fR
+\fBradeontop [\-chmv] [\-b \fR\fB\fIbus\fR\fR\fB] [\-d \fR\fB\fIfile\fR\fR\fB] [\-i \fR\fB\fIseconds\fR\fR\fB] [\-l \fR\fB\fIlimit\fR\fR\fB] [\-t \fR\fB\fIticks\fR\fR\fB]\fR
 .SH "DESCRIPTION"
 .sp
 RadeonTop shows the utilization of your GPU, both in general and by blocks\&.

--- a/radeontop.c
+++ b/radeontop.c
@@ -30,7 +30,7 @@ static void version() {
 
 static void help(const char * const me, const unsigned int ticks, const unsigned int dumpinterval) {
 	printf(_("\n\tRadeonTop for R600 and above.\n\n"
-		"\tUsage: %s [-ch] [-b bus] [-d file] [-i seconds] [-l limit] [-t ticks]\n\n"
+		"\tUsage: %s [-chmv] [-b bus] [-d file] [-i seconds] [-l limit] [-t ticks]\n\n"
 		"-b --bus 3		Pick card from this PCI bus (hexadecimal)\n"
 		"-c --color		Enable colors\n"
 		"-d --dump file		Dump data to this file, - for stdout\n"

--- a/ticks.c
+++ b/ticks.c
@@ -39,7 +39,8 @@ static void *collector(void *arg) {
 	const useconds_t sleeptime = 1e6 / ticks;
 
 	while (1) {
-		unsigned int stat = readgrbm();
+		unsigned int stat;
+		getgrbm(&stat);
 
 		memset(&history[cur], 0, sizeof(struct bits_t));
 
@@ -57,8 +58,8 @@ static void *collector(void *arg) {
 		if (stat & bits.db) history[cur].db = 1;
 		if (stat & bits.cr) history[cur].cr = 1;
 		if (stat & bits.cb) history[cur].cb = 1;
-		history[cur].mclk = getmclk();
-		history[cur].sclk = getsclk();
+		getsclk(&history[cur].sclk);
+		getmclk(&history[cur].mclk);
 
 		usleep(sleeptime);
 		cur++;
@@ -89,8 +90,8 @@ static void *collector(void *arg) {
 				res[curres].sclk += history[i].sclk;
 			}
 
-			res[curres].vram = getvram();
-			res[curres].gtt = getgtt();
+			getvram(&res[curres].vram);
+			getgtt(&res[curres].gtt);
 
 			// Atomically write it to the pointer
 			__sync_bool_compare_and_swap(&results, results, &res[curres]);

--- a/ui.c
+++ b/ui.c
@@ -253,7 +253,7 @@ void present(const unsigned int ticks, const char card[], unsigned int color,
 			}
 		}
 
-		if (mclk_max != 0 && mclk > 0) {
+		if (sclk_max != 0 && sclk > 0) {
 			if (color) attron(COLOR_PAIR(3));
 			percentage(start, w, mclk);
 			printright(start++, hw, _("%.2fG / %.2fG Memory Clock %6.2f%%"),


### PR DESCRIPTION
This patch series adds the clock frequency reporting for radeon and display it on APUs too. Code was refactored to split device dependent parts to amdgpu.c and radeon.c. DRM version is now checked to better report errors to the user.

Tested on Linux with amdgpu and radeon, with 32 and 64 bit builds, on KAVERI APU.

There are two unresolved caveats, because the maximum memory clock is not available when using radeon and the current memory clock is not available on APUs when using amdgpu. It will show an empty graph labeled like "0.80G / 0.00G Memory Clock    inf%" or "0.00G / 0.80G Memory Clock   0.00%". May be this line should be disabled in these cases or is this useful anyway?

ciao!