### PR TITLE
Round the size of the percentage bar to the nearest integer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ LDFLAGS ?= -Wl,-O1
 LDFLAGS += $(LDFLAGS_SECTIONED)
 LIBS += $(shell pkg-config --libs pciaccess)
 LIBS += $(shell pkg-config --libs libdrm)
+LIBS += -lm
 ifeq ($(xcb), 1)
 	xcb_LIBS += $(shell pkg-config --libs xcb xcb-dri2)
 	LIBS += -ldl

--- a/ui.c
+++ b/ui.c
@@ -15,6 +15,7 @@
 */
 
 #include "radeontop.h"
+#include <math.h>
 #include <ncurses.h>
 #include <stdarg.h>
 
@@ -69,7 +70,7 @@ static void percentage(const unsigned int y, const unsigned int w, const float p
 	const unsigned int x = (w/2) + 2;
 	unsigned int len = w - x - 1;
 
-	len = len * (p / 100.0);
+	len = roundf(len * (p / 100.0f));
 
 	attron(A_REVERSE);
 	mvhline(y, x, ' ', len);


### PR DESCRIPTION
Also, avoid superfluous conversions between 64-bit and 32-bit floats by using 100.0f instead of 100.0.

Please merge.
Thanks.