### PR TITLE
Don't access srbm when disabled

### DIFF
--- a/ticks.c
+++ b/ticks.c
@@ -42,9 +42,9 @@ static void *collector(void *arg) {
 		unsigned int stat;
 		getgrbm(&stat);
 		unsigned int uvd;
-		getsrbm(&uvd);
+		if (bits.uvd) getsrbm(&uvd);
 		unsigned int vce;
-		getsrbm2(&vce);
+		if (bits.vce0) getsrbm2(&vce);
 
 		memset(&history[cur], 0, sizeof(struct bits_t));
 


### PR DESCRIPTION
This fixes a bug I introduced with #140.

Other GPUs such as laptop GPUs and older/newer GPUs have a different memory layout. I was told to add a check to disable the video encode/decode detection feature on those GPUs, but I accidentally only added a check during display. I missed the if statements around the actual memory reads. This PR adds these missing conditionals.

It is weird that a read (strange but I suppose it could happen when we get to hardware and might be expected from my experience of AMD drivers being unstable) is causing the problems, especially in userspace. There is also code doing `mmap` of these registers that ideally should be wrapped in the same condition, but it's architecturally complicated because `initbits(int)` is called after `init_pci` and there are a lot of data dependencies, so that code isn't changed. Also, I was originally planning to suggest the alternative solution of disabling the bits on laptop APUs, but that wouldn't have worked without the PR. Thanks to @madushan1000 in #149 for leading me to this solution by mentioning that his GPU is a model that the original if statement already excludes and that commenting it out did nothing, which made me look elsewhere and find this solution.