### PR TITLE
Use family_id and external_rev_id to detect GFX11/RDNA3, Raphael APU, Me…

### DIFF
--- a/amdgpu.c
+++ b/amdgpu.c
@@ -19,8 +19,13 @@
 #include <libdrm/amdgpu_drm.h>
 #include <libdrm/amdgpu.h>
 
-uint32_t family_id;
-uint32_t chip_external_rev;
+#define FAMILY_GFX1100 0x91
+#define FAMILY_GFX1103 0x94
+#define FAMILY_GC_10_3_6 0x95
+#define FAMILY_GC_10_3_7 0x97
+
+static uint32_t family_id;
+static uint32_t chip_external_rev;
 
 static amdgpu_device_handle amdgpu_dev;
 

--- a/amdgpu.c
+++ b/amdgpu.c
@@ -24,8 +24,8 @@
 #define FAMILY_GC_10_3_6 0x95
 #define FAMILY_GC_10_3_7 0x97
 
-static uint32_t family_id;
-static uint32_t chip_external_rev;
+static uint32_t family_id = 0;
+static uint32_t chip_external_rev = 0;
 
 static amdgpu_device_handle amdgpu_dev;
 

--- a/detect.c
+++ b/detect.c
@@ -332,6 +332,13 @@ void cleanup() {
 
 int getfamily(unsigned int id) {
 
+#ifdef ENABLE_AMDGPU
+	int family = getfamily_from_id();
+
+	if (family)
+		return family;
+#endif
+
 	switch(id) {
 		#define CHIPSET(a,b,c) case a: return c;
 		#include "r600_pci_ids.h"

--- a/family_str.c
+++ b/family_str.c
@@ -81,4 +81,11 @@ const char * const family_str[] = {
 	str(ALDEBARAN),
 	str(CYAN_SKILLFISH),
 	str(BEIGE_GOBY),
+	str(GFX1100),
+	str(GFX1101),
+	str(GFX1102),
+	str(GFX1103_R1),
+	str(GFX1103_R2),
+	str(GFX1036),
+	str(GFX1037),
 };

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -138,6 +138,13 @@ enum radeon_family {
 	ALDEBARAN,
 	CYAN_SKILLFISH,
 	BEIGE_GOBY,
+	GFX1100, // Navi31
+	GFX1101, // Navi32
+	GFX1102, // Navi33
+	GFX1103_R1,  // Phoenix
+	GFX1103_R2, // Phoenix
+	GFX1036, // Raphael
+	GFX1037, // Mendocino
 };
 
 extern const char * const family_str[];
@@ -171,6 +178,18 @@ extern uint64_t vramsize;
 extern uint64_t gttsize;
 extern unsigned int sclk_max;
 extern unsigned int mclk_max;
+
+#ifdef ENABLE_AMDGPU
+extern uint32_t family_id;
+extern uint32_t chip_external_rev;
+int getfamily_from_id();
+
+#define FAMILY_GFX1100 0x91
+#define FAMILY_GFX1103 0x94
+#define FAMILY_GC_10_3_6 0x95
+#define FAMILY_GC_10_3_7 0x97
+
+#endif
 
 // radeon.c
 void init_radeon(int fd, int drm_major, int drm_minor);

--- a/include/radeontop.h
+++ b/include/radeontop.h
@@ -179,23 +179,12 @@ extern uint64_t gttsize;
 extern unsigned int sclk_max;
 extern unsigned int mclk_max;
 
-#ifdef ENABLE_AMDGPU
-extern uint32_t family_id;
-extern uint32_t chip_external_rev;
-int getfamily_from_id();
-
-#define FAMILY_GFX1100 0x91
-#define FAMILY_GFX1103 0x94
-#define FAMILY_GC_10_3_6 0x95
-#define FAMILY_GC_10_3_7 0x97
-
-#endif
-
 // radeon.c
 void init_radeon(int fd, int drm_major, int drm_minor);
 
 // amdgpu.c
 void init_amdgpu(int fd);
 void cleanup_amdgpu();
+int getfamily_from_id();
 
 #endif

--- a/radeontop.c
+++ b/radeontop.c
@@ -139,12 +139,15 @@ int main(int argc, char **argv) {
 
 	setuid(getuid());
 
-	const int family = getfamily(device_id);
+	int family = getfamily(device_id);
+#ifdef ENABLE_AMDGPU
+	if (!family)
+	   family = getfamily_from_id();
+#endif
 	if (!family)
 		puts(_("Unknown Radeon card. <= R500 won't work, new cards might."));
 
 	const char * const cardname = family_str[family];
-
 	initbits(family);
 
 	// runtime

--- a/radeontop.c
+++ b/radeontop.c
@@ -139,11 +139,7 @@ int main(int argc, char **argv) {
 
 	setuid(getuid());
 
-	int family = getfamily(device_id);
-#ifdef ENABLE_AMDGPU
-	if (!family)
-	   family = getfamily_from_id();
-#endif
+	const int family = getfamily(device_id);
 	if (!family)
 		puts(_("Unknown Radeon card. <= R500 won't work, new cards might."));
 


### PR DESCRIPTION
…ndocino APU

`family_id` and `external_rev_id` can be used to identify most AMD GPUs, but for now use them for GPUs that are not in the database.

Resolve #151
Resolve #153

## Reference
 * <https://gitlab.freedesktop.org/mesa/mesa/blob/main/src/amd/addrlib/src/amdgpu_asic_addr.h>
 * <https://gitlab.freedesktop.org/mesa/mesa/blob/main/src/amd/common/amd_family.c>