### PR TITLE
use stderr for error messages and for ncurses ui

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -45,12 +45,12 @@ void dumpdata(const unsigned int ticks, const char file[], const unsigned int li
 	sigaction(SIGTERM, &sig, NULL);
 	sigaction(SIGINT, &sig, NULL);
 
-	printf(_("Dumping to %s, "), file);
+	fprintf(stderr, _("Dumping to %s, "), file);
 
 	if (limit)
-		printf(_("line limit %u.\n"), limit);
+		fprintf(stderr, _("line limit %u.\n"), limit);
 	else
-		puts(_("until termination."));
+		fputs(_("until termination.\n"), stderr);
 
 	// Check the file can be output to
 	FILE *f = NULL;

--- a/radeontop.c
+++ b/radeontop.c
@@ -19,7 +19,7 @@
 #include <getopt.h>
 
 void die(const char * const why) {
-	puts(why);
+	fprintf(stderr, "%s\n", why);
 	exit(1);
 }
 
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
 
 	const int family = getfamily(device_id);
 	if (!family)
-		puts(_("Unknown Radeon card. <= R500 won't work, new cards might."));
+		fprintf(stderr, _("Unknown Radeon card. <= R500 won't work, new cards might.\n"));
 
 	const char * const cardname = family_str[family];
 

--- a/ui.c
+++ b/ui.c
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <ncurses.h>
 #include <stdarg.h>
+#include <stdio.h>
 
 static void printcenter(const unsigned int y, const unsigned int width,
 				const char * const fmt, ...) {
@@ -87,7 +88,7 @@ void present(const unsigned int ticks, const char card[], unsigned int color,
 	while(!results)
 		usleep(16000);
 
-	initscr();
+	newterm(NULL, stderr, stdin);
 	noecho();
 	halfdelay(10);
 	curs_set(0);


### PR DESCRIPTION
I tried writing a shell script which parses the output of `radeontop -d -` and found that I had to filter out the first two lines
```
Unknown Radeon card. <= R500 won't work, new cards might.
Dumping to -, line limit 1.
```
Printing metadata like this to stderr for humans to see while and reserving stdout for the actual data makes piping a lot easier. Despite the name, stderr isn't just errors, it's generally for anything intended for humans and not meaningful in shell scripts. That also includes the ncurses UI, which typically uses stderr.
These changes should make no difference in normal cases but be a lot more predictable in specific cases.