### PR TITLE
Fix GRBM_STATUS bit positions for RDNA (GFX10+) GPUs

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -377,4 +377,12 @@ void initbits(int fam) {
 			bits.vce0 = (1U << 7);
 		}
 	}
+
+	// RDNA (GFX10+): VGT replaced by Geometry Engine at bit 21,
+	// Event Engine and Sequencer Instruction Cache bits undefined.
+	if (fam >= NAVI10) {
+		bits.ee = 0;
+		bits.vgt = (1U << 21);
+		bits.sh = 0;
+	}
 }

--- a/dump.c
+++ b/dump.c
@@ -108,15 +108,17 @@ void dumpdata(const unsigned int ticks, const char file[], const unsigned int li
 		float sclk_ghz = results->sclk * k / 1000.0f;
 
 		fprintf(f, "gpu %.2f%%, ", gui);
-		fprintf(f, "ee %.2f%%, ", ee);
-		fprintf(f, "vgt %.2f%%, ", vgt);
+		if (bits.ee)
+			fprintf(f, "ee %.2f%%, ", ee);
+		fprintf(f, "%s %.2f%%, ", bits.ee ? "vgt" : "ge", vgt);
 		fprintf(f, "ta %.2f%%, ", ta);
 
 		if (bits.tc)
 			fprintf(f, "tc %.2f%%, ", tc);
 
 		fprintf(f, "sx %.2f%%, ", sx);
-		fprintf(f, "sh %.2f%%, ", sh);
+		if (bits.sh)
+			fprintf(f, "sh %.2f%%, ", sh);
 		fprintf(f, "spi %.2f%%, ", spi);
 
 		if (bits.smx)

--- a/ui.c
+++ b/ui.c
@@ -175,15 +175,20 @@ void present(const unsigned int ticks, const char card[], unsigned int color,
 
 		unsigned int start = 4;
 
-		percentage(start, w, ee);
-		printright(start++, hw, _("Event Engine %6.2f%%"), ee);
+		if (bits.ee) {
+			percentage(start, w, ee);
+			printright(start++, hw, _("Event Engine %6.2f%%"), ee);
 
-		// Enough height?
-		if (h > bigh) start++;
+			// Enough height?
+			if (h > bigh) start++;
+		}
 
 		if (color) attron(COLOR_PAIR(2));
 		percentage(start, w, vgt);
-		printright(start++, hw, _("Vertex Grouper + Tesselator %6.2f%%"), vgt);
+		if (bits.ee)
+			printright(start++, hw, _("Vertex Grouper + Tesselator %6.2f%%"), vgt);
+		else
+			printright(start++, hw, _("Geometry Engine %6.2f%%"), vgt);
 		if (color) attroff(COLOR_PAIR(2));
 
 		// Enough height?
@@ -207,8 +212,10 @@ void present(const unsigned int ticks, const char card[], unsigned int color,
 		percentage(start, w, sx);
 		printright(start++, hw, _("Shader Export %6.2f%%"), sx);
 
-		percentage(start, w, sh);
-		printright(start++, hw, _("Sequencer Instruction Cache %6.2f%%"), sh);
+		if (bits.sh) {
+			percentage(start, w, sh);
+			printright(start++, hw, _("Sequencer Instruction Cache %6.2f%%"), sh);
+		}
 
 		percentage(start, w, spi);
 		printright(start++, hw, _("Shader Interpolator %6.2f%%"), spi);


### PR DESCRIPTION
## Summary

Independent of #178 — can be merged separately.

On RDNA (GFX10+), the GRBM_STATUS register layout changed from GCN:

| Field | GCN bit(s) | RDNA bit | Status |
|---|---|---|---|
| Event Engine | bit 10 | reserved | zeroed |
| VGT | bits 16-17 | replaced by GE (bit 21) | remapped |
| Seq. Instr. Cache | bit 21 | now GE_BUSY | zeroed |
| TA, SX, SPI, SC, PA, DB, CB, GUI | unchanged | unchanged | OK |

The VGT field now reads GE_BUSY (Geometry Engine, bit 21) which is the functional successor to VGT on RDNA.

## Test plan

- [x] On RDNA card: VGT/GE shows plausible utilization (not stuck at 0% or 100%)
- [ ] On GCN card: no change in behavior
- [x] EE and SH show 0% on RDNA (correct — these blocks don't exist)